### PR TITLE
Expand Intro Skip Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Jetbrains IDE
+**/.idea/*

--- a/p3rpc.essentials/Config.cs
+++ b/p3rpc.essentials/Config.cs
@@ -20,6 +20,19 @@ public class Config : Configurable<Config>
     [Description("Skips the section asking you whether you want network features.\nDoing this will cause network features to be off.")]
     [DefaultValue(false)]
     public bool NetworkSkip { get; set; } = false;
+    
+    [DisplayName("Intro Skip (Episode Aigis)")]
+    [Category("Intro Skip")]
+    [Description("Skip to the main menu for Episode Aigis.")]
+    [DefaultValue(false)]
+    public bool IntroSkipAstrea { get; set; } = false;
+    // public IntroPartAstrea IntroSkipAstrea { get; set; } = IntroPartAstrea.None;
+    
+    [DisplayName("Fast Menu Navigation")]
+    [Category("Intro Skip")]
+    [Description("Let the user make inputs in the title menu immediately.")]
+    [DefaultValue(false)]
+    public bool FastMenuNavigation { get; set; } = false;
 
     public enum IntroPart
     {
@@ -28,7 +41,6 @@ public class Config : Configurable<Config>
         MainMenu,
         LoadMenu
     }
-
 }
 
 /// <summary>

--- a/p3rpc.essentials/ModConfig.json
+++ b/p3rpc.essentials/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "p3rpc.essentials",
   "ModName": "Persona 3 Reload Essentials",
   "ModAuthor": "AnimatedSwine37",
-  "ModVersion": "1.2.1",
+  "ModVersion": "1.3.0",
   "ModDescription": "Provides base modding support for P3R and miscellaneous fixes.",
   "ModDll": "p3rpc.essentials.dll",
   "ModIcon": "Preview.png",

--- a/p3rpc.essentials/Patches/IntroSkip.cs
+++ b/p3rpc.essentials/Patches/IntroSkip.cs
@@ -4,87 +4,239 @@ using static p3rpc.essentials.Configuration.Config;
 using IReloadedHooks = Reloaded.Hooks.ReloadedII.Interfaces.IReloadedHooks;
 
 namespace p3rpc.essentials.Patches;
+
+internal enum ETitleState : byte
+{
+    TS_Caution = 0,
+    TS_PhotosensitiveCaution = 1,
+    TS_NetworkCheck = 2,
+    TS_Logo = 3,
+    TS_OP = 4,
+    TS_PressWait = 5,
+    TS_Select = 6,
+    TS_NewGame = 7,
+    TS_LoadGame = 8,
+    TS_Config = 9,
+    TS_Exit = 10,
+    TS_ComeBackLoad = 11,
+    TS_WaitGamerTag = 12,
+    TS_ResidentReload = 13,
+    TS_OP_Astrea = 14,
+    TS_PressWait_Astrea = 15,
+    TS_Select_Astrea = 16,
+    TS_Num = 17,
+    TS_MAX = 18,
+}
+
 internal unsafe class IntroSkip
 {
     private static IReloadedHooks _hooks;
 
-    private static IHook<GetStateDelegate> _introHook;
-    private static IHook<GetStateDelegate> _cautionHook;
+    private static IHook<GetStateDelegate>? _introHook;
+    private static IHook<GetStateDelegate>? _cautionHook;
+    private static IHook<GetStateDelegate>? _introHookAstrea;
+    private static IHook<GetStateDelegate>? _introHookOP;
+    private static IHook<GetStateDelegate>? _pressWaitHook;
+    private static IHook<GetStateDelegate>? _selectHook;
+    private static IHook<GetStateDelegate>? _selectHookAstrea;
 
     private static NextStateDelegate? _introNextState;
+    private static NextStateDelegate? _pressWaitNextState;
+    private static NextStateDelegate? _opNextState;
+    private static NextStateDelegate? _introNextStateAstrea;
+
+    private static bool JumpToLoadState = false;
+    private static bool InitialLoad = false;
 
     public static void Activate(IReloadedHooks hooks)
     {
         _hooks = hooks;
-        Utils.SigScan("48 8B C4 53 57 41 57 48 81 EC D0 00 00 00", "Intro Skip", address =>
-        {
-            _introHook = hooks.CreateHook<GetStateDelegate>(Intro, address).Activate();
-        });
-
+        
         Utils.SigScan("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 80 B9 ?? ?? ?? ?? 00 48 8B D9", "Caution Skip", address =>
         {
             _cautionHook = hooks.CreateHook<GetStateDelegate>(Caution, address).Activate();
         });
     }
 
-    private static byte Caution(IntroPartInfo* info, float param_2)
+    private static ETitleState Caution(UTitleStateBase* self, float delta)
     {
-        var res = _cautionHook.OriginalFunction(info, param_2);
+        var res = _cautionHook.OriginalFunction(self, delta);
 
         var skip = Mod.Configuration.IntroSkip;
         if (skip == IntroPart.None) return res;
 
+        var TitleActor = self->TitleActor;
+        for (var i = 0; i < TitleActor->StateCount; i++)
+        {
+            var CurrState = TitleActor->StateAlloc[i].Value;
+            switch (TitleActor->StateAlloc[i].Key)
+            {
+                case ETitleState.TS_Logo:
+                    _introHook ??= _hooks.CreateHook<GetStateDelegate>(Intro, 
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                case ETitleState.TS_PressWait:
+                    _pressWaitHook ??= _hooks.CreateHook<GetStateDelegate>(PressWait, 
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                case ETitleState.TS_OP:
+                    _introHookOP ??= _hooks.CreateHook<GetStateDelegate>(IntroOP,
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                case ETitleState.TS_Select:
+                    _selectHook ??= _hooks.CreateHook<GetStateDelegate>(Select, 
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                case ETitleState.TS_OP_Astrea:
+                    _introHookAstrea ??= _hooks.CreateHook<GetStateDelegate>(IntroAstrea, 
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                case ETitleState.TS_Select_Astrea:
+                    _selectHookAstrea ??= _hooks.CreateHook<GetStateDelegate>(SelectAstrea, 
+                        (long)CurrState->VTable->UpdateState).Activate();
+                    break;
+                default:
+                    continue;
+            }
+        }
+
         if (!Mod.Configuration.NetworkSkip)
         {
             Utils.Log("Skipping to the network settings");
-            return 2;
+            return ETitleState.TS_NetworkCheck;
         }
 
-        return 3; // Skip past network and caution
+        return ETitleState.TS_Logo; // Skip past network and caution
     }
 
-    private static byte Intro(IntroPartInfo* info, float param2)
+    private static ETitleState Intro(UTitleStateBase* self, float delta)
     {
-        var res = _introHook.OriginalFunction(info, param2);
-        if (res != 3) return res;
+        var res = _introHook.OriginalFunction(self, delta);
 
-        var skip = Mod.Configuration.IntroSkip;
-        if (skip == IntroPart.OpeningMovie)
+        if (res != ETitleState.TS_Logo) return res;
+        InitialLoad = true;
+        switch (Mod.Configuration.IntroSkip)
         {
-            Utils.Log("Skipping to the opening movie");
-            if (_introNextState == null)
-                _introNextState = _hooks.CreateWrapper<NextStateDelegate>((long)info->VTable->NextState, out _);
+            case IntroPart.OpeningMovie:
+                Utils.Log("Skipping to the opening movie");
+                _introNextState ??= _hooks.CreateWrapper<NextStateDelegate>((long)self->VTable->NextState, out _);
+                return _introNextState(self);
+            case IntroPart.MainMenu:
+            // case IntroPart.LoadMenu:
+                Utils.Log("Skipping to the main menu");
+                return ETitleState.TS_PressWait; 
+            case IntroPart.LoadMenu:
+                Utils.Log("Skipping to the load menu");
+                return ETitleState.TS_LoadGame;
+            default:
+                return res;
+        }
+    }
 
-            return _introNextState(info);
+    private static ETitleState PressWait(UTitleStateBase* self, float delta)
+    {
+        if (Mod.Configuration.FastMenuNavigation)
+            *(float*)((nint)self + 0x50) = 1.75f; // DT_TitleUI->PleaseWaitFadeInWaitTime
+        return _pressWaitHook.OriginalFunction(self, delta);
+        // var res = _pressWaitHook.OriginalFunction(self, delta);
+        // if (res != ETitleState.TS_PressWait) return res;
+        /*
+        if (Mod.Configuration.IntroSkip == IntroPart.LoadMenu && !JumpToLoadState)
+        { 
+            JumpToLoadState = true;
+            // _pressWaitNextState ??= _hooks.CreateWrapper<NextStateDelegate>((long)self->VTable->NextState, out _);
+            // return _pressWaitNextState(self);
+            return ETitleState.TS_LoadGame;
         }
-        else if (skip == IntroPart.MainMenu)
+        */
+        // return res;
+    }
+    
+    private static ETitleState SelectInner(UTitleStateBase* self, float delta, IHook<GetStateDelegate> Delegate)
+    {
+        if (Mod.Configuration.FastMenuNavigation && self->TitleActor != null && !self->TitleActor->Input.InputControl0)
         {
-            Utils.Log("Skipping to the main menu");
-            return 5;
+            var ActorInput = &self->TitleActor->Input;
+            for (var i = 0; i < ActorInput->EntryCount; i++)
+                ActorInput->Entries[i].ValCur = ActorInput->Entries[i].ValEnd;
+            ActorInput->InputControl0 = true;
+            ActorInput->InputControl1 = true;
         }
-        else if (skip == IntroPart.LoadMenu)
-        {
-            Utils.Log("Skipping to the load menu");
-            return 8;
-        }
+        return Delegate.OriginalFunction(self, delta);
+    }
 
-        return res;
+    private static ETitleState Select(UTitleStateBase* self, float delta)
+        => SelectInner(self, delta, _selectHook);
+    
+    private static ETitleState SelectAstrea(UTitleStateBase* self, float delta)
+        => SelectInner(self, delta, _selectHookAstrea);
+
+    private static ETitleState IntroOP(UTitleStateBase* self, float delta)
+    {
+        var res = _introHookOP.OriginalFunction(self, delta);
+        if (res != ETitleState.TS_OP || !Mod.Configuration.IntroSkipAstrea) return res;
+        // return InitialLoad ? ETitleState.TS_ResidentReload : ETitleState.TS_PressWait;
+        Utils.Log("Skipping to the main menu");
+        _opNextState ??= _hooks.CreateWrapper<NextStateDelegate>((long)self->VTable->NextState, out _);
+        return _opNextState(self);
+    }
+
+    private static ETitleState IntroAstrea(UTitleStateBase* self, float delta)
+    {
+        var res = _introHookAstrea.OriginalFunction(self, delta);
+        if (res != ETitleState.TS_OP_Astrea || !Mod.Configuration.IntroSkipAstrea) return res;
+        Utils.Log("Skipping to the main menu");
+        _introNextStateAstrea ??= _hooks.CreateWrapper<NextStateDelegate>((long)self->VTable->NextState, out _);
+        return _introNextStateAstrea(self);           
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    private struct IntroPartInfo
+    private struct UTitleStatBaseVtable
     {
-        [FieldOffset(0)]
-        internal IntroPartVTable* VTable;
+        [FieldOffset(0x280)] internal nuint UpdateState;
+        [FieldOffset(0x298)] internal nuint NextState;
     }
-
+    
     [StructLayout(LayoutKind.Explicit)]
-    private struct IntroPartVTable
+    private struct UTitleStateBase
     {
-        [FieldOffset(0x298)]
-        internal nuint NextState;
+        [FieldOffset(0x0)] internal UTitleStatBaseVtable* VTable;
+        [FieldOffset(0x30)] internal ATitleActor* TitleActor;
     }
 
-    private delegate byte GetStateDelegate(IntroPartInfo* info, float param2);
-    private delegate byte NextStateDelegate(IntroPartInfo* info);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TitleStateBase
+    {
+        internal ETitleState Key;
+        internal UTitleStateBase* Value;
+        internal int NextHashId;
+        internal int HashIndex;
+    }
+    
+    [StructLayout(LayoutKind.Explicit)]
+    private struct ATitleActor
+    {
+        [FieldOffset(0x288)] internal TitleStateBase* StateAlloc;
+        [FieldOffset(0x290)] internal int StateCount;
+        [FieldOffset(0x478)] internal ATitleActorInput Input;
+    }
+    
+    [StructLayout(LayoutKind.Explicit)]
+    private struct ATitleActorInput
+    {
+        [FieldOffset(0x20)] internal ATitleActorInputEntry* Entries;
+        [FieldOffset(0x28)] internal int EntryCount;
+        [FieldOffset(0x85)] public bool InputControl0;
+        [FieldOffset(0xb5)] public bool InputControl1;
+    }
+    
+    [StructLayout(LayoutKind.Explicit, Size = 0x358)]
+    private struct ATitleActorInputEntry
+    {
+        [FieldOffset(0x248)] internal float ValEnd;
+        [FieldOffset(0x250)] internal float ValCur;
+    }
+
+    private delegate ETitleState GetStateDelegate(UTitleStateBase* self, float delta);
+    private delegate ETitleState NextStateDelegate(UTitleStateBase* self);
 }

--- a/p3rpc.essentials/Patches/IntroSkip.cs
+++ b/p3rpc.essentials/Patches/IntroSkip.cs
@@ -174,7 +174,7 @@ internal unsafe class IntroSkip
     private static ETitleState IntroOP(UTitleStateBase* self, float delta)
     {
         var res = _introHookOP.OriginalFunction(self, delta);
-        if (res != ETitleState.TS_OP || !Mod.Configuration.IntroSkipAstrea) return res;
+        if (res != ETitleState.TS_OP || Mod.Configuration.IntroSkip == IntroPart.OpeningMovie) return res;
         // return InitialLoad ? ETitleState.TS_ResidentReload : ETitleState.TS_PressWait;
         Utils.Log("Skipping to the main menu");
         _opNextState ??= _hooks.CreateWrapper<NextStateDelegate>((long)self->VTable->NextState, out _);


### PR DESCRIPTION
Adds the following functionality into Intro Skip:
- Allows you to skip the intro movie when switching to Episode Aigis. This also fixes an issue where the opening movie plays when switching from Ep Aigis to base game regardless of the option set.
- Add Fast Menu Navigation to let the user start making inputs immediately, similar to how Metaphor's title screen works.
The way that the intro skip hooks into each state's update function was changed to only use one hook on caution, then use that to iterate through `ATitleActor`'s state map.